### PR TITLE
Make the package more configurable with a config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,12 @@ You can install the package via composer:
 composer require marcelweidum/filament-expiration-notice
 ```
 
+(Optional) When you want to publish the config file:
+
+```bash
+php artisan vendor:publish --tag="filament-expiration-notice-config"
+```
+
 (Optional) When you want to customize the expiration modal you can publish the view by running:
 
 ```bash

--- a/config/expiration-notice.php
+++ b/config/expiration-notice.php
@@ -1,7 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-return [
-    //
-];

--- a/config/filament-expiration-notice.php
+++ b/config/filament-expiration-notice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'heading' => 'Session Expired',
+    'description' => 'Your page session has expired due to inactivity. Please refresh the page to continue.',
+    'refresh_button' => 'Refresh page',
+];

--- a/resources/views/session-expired-modal.blade.php
+++ b/resources/views/session-expired-modal.blade.php
@@ -10,11 +10,11 @@
     footer-actions-alignment="center"
 >
     <x-slot name="heading">
-        {{ __('Session Expired') }}
+        {{ __(config('filament-expiration-notice.heading')) }}
     </x-slot>
 
     <x-slot name="description">
-        {{ __('Your page session has expired due to inactivity. Please refresh the page to continue.') }}
+        {{ __(config('filament-expiration-notice.description')) }}
     </x-slot>
 
     <x-slot name="footerActions">
@@ -24,7 +24,7 @@
             color="primary"
             class="w-full"
         >
-            {{ __('Refresh page') }}
+            {{ __(config('filament-expiration-notice.refresh_button')) }}
         </x-filament::button>
     </x-slot>
 </x-filament::modal>

--- a/src/ExpirationNoticeServiceProvider.php
+++ b/src/ExpirationNoticeServiceProvider.php
@@ -62,7 +62,7 @@ final class ExpirationNoticeServiceProvider extends PackageServiceProvider
         );
     }
 
-    protected function getAssetPackageName(): ?string
+    protected function getAssetPackageName(): string
     {
         return 'marcelweidum/filament-expiration-notice';
     }


### PR DESCRIPTION
This pull request introduces enhancements to the `filament-expiration-notice` package, including the addition of a configuration file, dynamic modal content customization, and minor adjustments to the service provider's implementation. The changes aim to improve flexibility and usability for developers integrating the package.

### Configuration and Customization Enhancements:

* **Added configuration file for dynamic modal content:**
  - Created `config/filament-expiration-notice.php` to define customizable text for the session expiration modal, including `heading`, `description`, and `refresh_button`.
  - Removed the unused `config/expiration-notice.php` file.

* **Updated modal view to use configuration values:**
  - Modified `resources/views/session-expired-modal.blade.php` to dynamically pull `heading`, `description`, and `refresh_button` values from the configuration file. [[1]](diffhunk://#diff-d9d6fe7b26356c4074a636c920d9bfd32c3ffe9b8544086c825c4553471d4effL13-R17) [[2]](diffhunk://#diff-d9d6fe7b26356c4074a636c920d9bfd32c3ffe9b8544086c825c4553471d4effL27-R27)

### Documentation Updates:

* **Improved installation instructions:**
  - Updated `README.md` to include optional steps for publishing the configuration file using `php artisan vendor:publish --tag="filament-expiration-notice-config"`.

### Code Refinements:

* **Adjusted service provider method:**
  - Updated `ExpirationNoticeServiceProvider.php` to ensure `getAssetPackageName()` returns a non-null string instead of a nullable type.