### PR TITLE
Translations

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ You can install the package via composer:
 composer require marcelweidum/filament-expiration-notice
 ```
 
-(Optional) When you want to publish the config file:
-
-```bash
-php artisan vendor:publish --tag="filament-expiration-notice-config"
-```
-
 (Optional) When you want to customize the expiration modal you can publish the view by running:
 
 ```bash
 php artisan vendor:publish --tag="filament-expiration-notice-views"
+```
+
+If you want to customize the translations, you can publish the translations by running:
+
+```bash
+php artisan vendor:publish --tag="filament-expiration-notice-translations"
 ```
 
 ## Contributing

--- a/config/filament-expiration-notice.php
+++ b/config/filament-expiration-notice.php
@@ -3,7 +3,5 @@
 declare(strict_types=1);
 
 return [
-    'heading' => 'Session Expired',
-    'description' => 'Your page session has expired due to inactivity. Please refresh the page to continue.',
-    'refresh_button' => 'Refresh page',
+    //
 ];

--- a/resources/lang/de/expiration-notice.php
+++ b/resources/lang/de/expiration-notice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'heading' => 'Sitzung abgelaufen',
+    'description' => 'Ihre Sitzung ist aufgrund von Inaktivität abgelaufen. Bitte laden Sie die Seite neu, um fortzufahren.',
+    'button' => 'Seite neu laden',
+];

--- a/resources/lang/en/expiration-notice.php
+++ b/resources/lang/en/expiration-notice.php
@@ -3,5 +3,7 @@
 declare(strict_types=1);
 
 return [
-    //
+    'heading' => 'Session Expired',
+    'description' => 'Your page session has expired due to inactivity. Please refresh the page to continue.',
+    'button' => 'Refresh page',
 ];

--- a/resources/lang/nl/expiration-notice.php
+++ b/resources/lang/nl/expiration-notice.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'heading' => 'Sessie verlopen',
+    'description' => 'Uw pagina-sessie is verlopen door inactiviteit. Vernieuw de pagina om door te gaan.',
+    'button' => 'Vernieuw pagina',
+];

--- a/resources/views/session-expired-modal.blade.php
+++ b/resources/views/session-expired-modal.blade.php
@@ -10,11 +10,11 @@
     footer-actions-alignment="center"
 >
     <x-slot name="heading">
-        {{ __(config('filament-expiration-notice.heading')) }}
+        {{ __('filament-expiration-notice::expiration-notice.heading') }}
     </x-slot>
 
     <x-slot name="description">
-        {{ __(config('filament-expiration-notice.description')) }}
+        {{ __('filament-expiration-notice::expiration-notice.description') }}
     </x-slot>
 
     <x-slot name="footerActions">
@@ -24,7 +24,7 @@
             color="primary"
             class="w-full"
         >
-            {{ __(config('filament-expiration-notice.refresh_button')) }}
+            {{ __('filament-expiration-notice::expiration-notice.button') }}
         </x-filament::button>
     </x-slot>
 </x-filament::modal>

--- a/src/ExpirationNoticeServiceProvider.php
+++ b/src/ExpirationNoticeServiceProvider.php
@@ -10,8 +10,6 @@ use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
 use Illuminate\View\View;
-use Livewire\Features\SupportTesting\Testable;
-use MarcelWeidum\ExpirationNoticePlugin\Testing\TestsExpirationNoticePlugin;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;


### PR DESCRIPTION
This pull request introduces changes to improve the customization options for the expiration notice feature and refines how translations are handled. The most important changes include updates to the README documentation, removal of default configuration values, addition of multilingual support for translations, and modifications to the session expired modal view.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L23-R32): Updated instructions to clarify how to publish views and translations for customization. Removed the config publishing option and added new commands for views and translations.

### Configuration Cleanup:
* [`config/filament-expiration-notice.php`](diffhunk://#diff-357f55543c56e4e9ef17221b06f10f221e3c47b2f1868d7dff5dada649d6ea75L6-R6): Removed default configuration values for `heading`, `description`, and `refresh_button`, as these are now handled via translations.

### Multilingual Support:
* [`resources/lang/de/expiration-notice.php`](diffhunk://#diff-da0498d2a94f70a81ba410a0ab0130a1a460b7d47a2377d23eb34381e8002a93R1-R9): Added German translations for the expiration notice.
* [`resources/lang/en/expiration-notice.php`](diffhunk://#diff-f8ab0ffe840a0de0f187cc83bb26fab0e2f8005ea1ece6a1e5e3fa9c95518efeL6-R8): Added English translations for the expiration notice.
* [`resources/lang/nl/expiration-notice.php`](diffhunk://#diff-59645bf9ee772738e02119a7e978f086735277bf422573a6ede8b9161bfa0719R1-R9): Added Dutch translations for the expiration notice.

### View Modifications:
* [`resources/views/session-expired-modal.blade.php`](diffhunk://#diff-d9d6fe7b26356c4074a636c920d9bfd32c3ffe9b8544086c825c4553471d4effL13-R17): Updated the modal to use the new translation keys instead of configuration values for `heading`, `description`, and `button`. [[1]](diffhunk://#diff-d9d6fe7b26356c4074a636c920d9bfd32c3ffe9b8544086c825c4553471d4effL13-R17) [[2]](diffhunk://#diff-d9d6fe7b26356c4074a636c920d9bfd32c3ffe9b8544086c825c4553471d4effL27-R27)

### Code Cleanup:
* [`src/ExpirationNoticeServiceProvider.php`](diffhunk://#diff-2624f70571ca4e4f46c6c5722832af36f1ee475d60e9ab5b69c5843ba0263ac0L13-L14): Removed unused imports related to testing features.