### PR TITLE
Pint + workflow

### DIFF
--- a/.github/workflows/pint.yml
+++ b/.github/workflows/pint.yml
@@ -1,0 +1,23 @@
+name: PHP Linting (Pint)
+on:
+  workflow_dispatch:
+  push:
+    branches-ignore:
+      - 'dependabot/npm_and_yarn/*'
+jobs:
+  phplint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 2
+      - name: "laravel-pint"
+        uses: aglipanci/laravel-pint-action@0.1.0
+        with:
+          preset: laravel
+
+      - name: Commit changes
+        uses: stefanzweifel/git-auto-commit-action@v4
+        with:
+          commit_message: PHP Linting (Pint)
+          skip_fetch: true

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/marcelweidum/filament-expiration-notice.svg)](https://packagist.org/packages/marcelweidum/filament-expiration-notice)
 [![Total Downloads](https://img.shields.io/packagist/dt/marcelweidum/filament-expiration-notice.svg)](https://packagist.org/packages/marcelweidum/filament-expiration-notice)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/marcelweidum/filament-expiration-notice/tree/main/files/pint.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/marcelweidum/filament-expiration-notice/tree/main/files/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/marcelweidum/filament-expiration-notice/pint.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/marcelweidum/filament-expiration-notice/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
 ![Filament 3.x](https://img.shields.io/badge/Filament-3.x-EBB304)
 ![Filament 4.x](https://img.shields.io/badge/Filament-4.x-007ec6)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/marcelweidum/filament-expiration-notice.svg)](https://packagist.org/packages/marcelweidum/filament-expiration-notice)
 [![Total Downloads](https://img.shields.io/packagist/dt/marcelweidum/filament-expiration-notice.svg)](https://packagist.org/packages/marcelweidum/filament-expiration-notice)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/marcelweidum/filament-expiration-notice/tree/main/files/pint.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/marcelweidum/filament-expiration-notice/tree/main/files/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
 ![Filament 3.x](https://img.shields.io/badge/Filament-3.x-EBB304)
 ![Filament 4.x](https://img.shields.io/badge/Filament-4.x-007ec6)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/marcelweidum/filament-expiration-notice.svg)](https://packagist.org/packages/marcelweidum/filament-expiration-notice)
 [![Total Downloads](https://img.shields.io/packagist/dt/marcelweidum/filament-expiration-notice.svg)](https://packagist.org/packages/marcelweidum/filament-expiration-notice)
-[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/marcelweidum/filament-expiration-notice/pint.yml?branch=main&label=code%20style&style=flat-square)](https://github.com/marcelweidum/filament-expiration-notice/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
+[![GitHub Code Style Action Status](https://img.shields.io/github/actions/workflow/status/marcelweidum/filament-expiration-notice/pint.yml?branch=main&label=code%20style)](https://github.com/marcelweidum/filament-expiration-notice/actions?query=workflow%3A"Fix+PHP+code+styling"+branch%3Amain)
 ![Filament 3.x](https://img.shields.io/badge/Filament-3.x-EBB304)
 ![Filament 4.x](https://img.shields.io/badge/Filament-4.x-007ec6)
 

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "spatie/laravel-package-tools": "^1.15.0"
     },
     "require-dev": {
-        "laravel/pint": "^1.0",
+        "laravel/pint": "^1.22",
         "nunomaduro/collision": "^7.9",
         "nunomaduro/larastan": "^2.0.1",
         "orchestra/testbench": "^8.0",

--- a/src/ExpirationNoticeServiceProvider.php
+++ b/src/ExpirationNoticeServiceProvider.php
@@ -10,8 +10,6 @@ use Filament\Support\Facades\FilamentAsset;
 use Filament\Support\Facades\FilamentView;
 use Filament\View\PanelsRenderHook;
 use Illuminate\View\View;
-use Livewire\Features\SupportTesting\Testable;
-use MarcelWeidum\ExpirationNoticePlugin\Testing\TestsExpirationNoticePlugin;
 use Spatie\LaravelPackageTools\Commands\InstallCommand;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;


### PR DESCRIPTION
This pull request introduces PHP linting automation using Laravel Pint, updates the `README.md` with a new badge for code style status, and removes unused imports from the `ExpirationNoticeServiceProvider` class.

### Automation and tooling updates:
* [`.github/workflows/pint.yml`](diffhunk://#diff-179af40bc8e01bf99a9e562e955297861431b9204f42c966cb886cd57fd47ae0R1-R23): Added a new GitHub Actions workflow for PHP linting using Laravel Pint. This workflow runs on `ubuntu-latest`, ignores `dependabot/npm_and_yarn/*` branches, and automatically commits linting changes.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R5): Added a badge to display the status of the new PHP linting workflow.

### Code cleanup:
* [`src/ExpirationNoticeServiceProvider.php`](diffhunk://#diff-2624f70571ca4e4f46c6c5722832af36f1ee475d60e9ab5b69c5843ba0263ac0L13-L14): Removed unused imports, including `Testable` and `TestsExpirationNoticePlugin`, to clean up the code.