### PR TITLE
Change render hook for modal visibility

### DIFF
--- a/src/ExpirationNoticeServiceProvider.php
+++ b/src/ExpirationNoticeServiceProvider.php
@@ -55,7 +55,7 @@ final class ExpirationNoticeServiceProvider extends PackageServiceProvider
         );
 
         FilamentView::registerRenderHook(
-            PanelsRenderHook::PAGE_START,
+            PanelsRenderHook::BODY_START,
             fn (): View => view('filament-expiration-notice::session-expired-modal'),
         );
     }


### PR DESCRIPTION
This pull request updates the `packageBooted` method in `src/ExpirationNoticeServiceProvider.php` to modify the render hook used for displaying the session-expired modal.

* [`src/ExpirationNoticeServiceProvider.php`](diffhunk://#diff-2624f70571ca4e4f46c6c5722832af36f1ee475d60e9ab5b69c5843ba0263ac0L58-R58): Changed the render hook from `PanelsRenderHook::PAGE_START` to `PanelsRenderHook::BODY_START` to ensure the session-expired modal is rendered at the correct location in the DOM.